### PR TITLE
Output error messages to stderr instead of stdout (#24)

### DIFF
--- a/CommandLine/Builders/ConsoleAppBuilder.cs
+++ b/CommandLine/Builders/ConsoleAppBuilder.cs
@@ -101,7 +101,7 @@ namespace CommandLine.Builders
         public IConsoleAppHelpMenu ShowHelpMenu(string description, string commandLineExample)
         {
             // ReSharper disable once InvertIf
-            if (_data.ShowHelpMenu || _data.Errors.Count > 0)
+            if (!_data.DisableOutput && (_data.ShowHelpMenu || _data.Errors.Count > 0))
             {
                 Help.Show(_data.Ops, commandLineExample, description);
                 Console.WriteLine($"\n{_data.VersionProvider.DataVersion}\n");
@@ -122,9 +122,9 @@ namespace CommandLine.Builders
             // ReSharper disable once InvertIf
             if (_data.Errors.Count > 0)
             {
-                Console.WriteLine("\nSome problems were encountered when parsing the command line options:");
+                Console.Error.WriteLine("\nSome problems were encountered when parsing the command line options:");
                 PrintErrors();
-                Console.WriteLine("\nFor a complete list of command line options, type \"dotnet {0} -h\"", CommandLineUtilities.CommandFileName);
+                Console.Error.WriteLine("\nFor a complete list of command line options, type \"dotnet {0} -h\"", CommandLineUtilities.CommandFileName);
             }
 
             return new ConsoleAppErrors(_data);
@@ -134,11 +134,11 @@ namespace CommandLine.Builders
         {
             foreach (string error in _data.Errors)
             {
-                Console.Write("- ");
+                Console.Error.Write("- ");
                 Console.ForegroundColor = ConsoleColor.Red;
-                Console.Write("ERROR: ");
+                Console.Error.Write("ERROR: ");
                 Console.ResetColor();
-                Console.WriteLine(error);
+                Console.Error.WriteLine(error);
             }
         }
     }

--- a/ErrorHandling/ExitCodeUtilities.cs
+++ b/ErrorHandling/ExitCodeUtilities.cs
@@ -60,12 +60,12 @@ namespace ErrorHandling
 		public static ExitCodes ShowException(Exception e)
 		{
 			Console.ForegroundColor = ConsoleColor.Red;
-			Console.Write("\nERROR: ");
+			Console.Error.Write("\nERROR: ");
 			Console.ResetColor();
 
             while (e.InnerException != null) e = e.InnerException;
 
-            Console.WriteLine("{0}", e.Message);
+            Console.Error.WriteLine("{0}", e.Message);
 
 			var exceptionType = e.GetType();
 
@@ -74,18 +74,18 @@ namespace ErrorHandling
 			{
 				// print the stack trace
 				Console.ForegroundColor = ConsoleColor.Red;
-				Console.WriteLine("\nStack trace:");
+				Console.Error.WriteLine("\nStack trace:");
 				Console.ResetColor();
-				Console.WriteLine(e.StackTrace);
+				Console.Error.WriteLine(e.StackTrace);
 
 				// extract out the vcf line
 			    // ReSharper disable once InvertIf
 				if (e.Data.Contains(VcfLine))
 				{
 					Console.ForegroundColor = ConsoleColor.Red;
-					Console.WriteLine("\nVCF line:");
+					Console.Error.WriteLine("\nVCF line:");
 					Console.ResetColor();
-					Console.WriteLine(e.Data[VcfLine]);
+					Console.Error.WriteLine(e.Data[VcfLine]);
 				}
 			}
 


### PR DESCRIPTION
Write error messages to Console.Error.

Additionally, suppress the help (usage) message when stdout is being used for JSON output.