### PR TITLE
Multiple queries using Jasix do not produce valid JSON

### DIFF
--- a/Jasix/QueryProcessor.cs
+++ b/Jasix/QueryProcessor.cs
@@ -71,7 +71,7 @@ namespace Jasix
                 query.Chromosome = _jasixIndex.GetIndexChromName(query.Chromosome);
                 if (!_jasixIndex.ContainsChr(query.Chromosome)) continue;
 
-                count = PrintLargeVariantsExtendingIntoQuery(query);
+                count += PrintLargeVariantsExtendingIntoQuery(query);
                 count += PrintAllVariantsFromQueryBegin(query, count > 0);
             }
 


### PR DESCRIPTION
Briefly, if a user provides a list of queries to Jasix, each result is printed without a separating comma (and newline character). This PR should fix that.